### PR TITLE
Add /transaction/send endpoint & handle invalid tx in /transaction/send-multiple

### DIFF
--- a/xsuite-lightsimulnet/src/handleTransaction.go
+++ b/xsuite-lightsimulnet/src/handleTransaction.go
@@ -51,10 +51,9 @@ func (e *Executor) HandleTransactionSendMultiple(r *http.Request) (interface{}, 
 	for i, rawTx := range rawTxs {
 		e.txCounter += 1
 		txHash := uint64ToString(e.txCounter)
-		txsHashes[strconv.Itoa(i)] = txHash
 		err := e.executeTx(txHash, rawTx)
-		if err != nil {
-			return nil, err
+		if err == nil {
+			txsHashes[strconv.Itoa(i)] = txHash
 		}
 	}
 	jOutput := map[string]interface{}{

--- a/xsuite-lightsimulnet/src/handleTransaction.go
+++ b/xsuite-lightsimulnet/src/handleTransaction.go
@@ -39,7 +39,6 @@ func (e *Executor) HandleTransactionSend(r *http.Request) (interface{}, error) {
 	return jOutput, nil
 }
 
-
 func (e *Executor) HandleTransactionSendMultiple(r *http.Request) (interface{}, error) {
 	reqBody, _ := io.ReadAll(r.Body)
 	var rawTxs []RawTx
@@ -101,6 +100,9 @@ func (e *Executor) executeTx(txHash string, rawTx RawTx) (error) {
 	}
 	if rawTx.Version != 1 {
 		return errors.New("invalid version")
+	}
+	if rawTx.GasLimit < 50_000 {
+		return errors.New("insufficient gas limit")
 	}
 	tx := &model.TxStep{
 		Tx: &model.Transaction{

--- a/xsuite-lightsimulnet/src/handleTransaction.go
+++ b/xsuite-lightsimulnet/src/handleTransaction.go
@@ -17,6 +17,29 @@ import (
 	worldmock "github.com/multiversx/mx-chain-scenario-go/worldmock"
 )
 
+func (e *Executor) HandleTransactionSend(r *http.Request) (interface{}, error) {
+	reqBody, _ := io.ReadAll(r.Body)
+	var rawTx RawTx
+	err := json.Unmarshal(reqBody, &rawTx)
+	if err != nil {
+		return nil, err
+	}
+	e.txCounter += 1
+	txHash := uint64ToString(e.txCounter)
+	err = e.executeTx(txHash, rawTx)
+	if err != nil {
+		return nil, err
+	}
+	jOutput := map[string]interface{}{
+		"data": map[string]interface{}{
+			"txHash": txHash,
+		},
+		"code": "successful",
+	}
+	return jOutput, nil
+}
+
+
 func (e *Executor) HandleTransactionSendMultiple(r *http.Request) (interface{}, error) {
 	reqBody, _ := io.ReadAll(r.Body)
 	var rawTxs []RawTx

--- a/xsuite-lightsimulnet/src/main.go
+++ b/xsuite-lightsimulnet/src/main.go
@@ -43,6 +43,11 @@ func main() {
 		respond(w, resBody, err)
 	})
 
+	router.Post("/transaction/send", func(w http.ResponseWriter, r *http.Request) {
+		resBody, err := executor.HandleTransactionSend(r)
+		respond(w, resBody, err)
+	})
+
 	router.Post("/transaction/send-multiple", func(w http.ResponseWriter, r *http.Request) {
 		resBody, err := executor.HandleTransactionSendMultiple(r)
 		respond(w, resBody, err)

--- a/xsuite/src/proxy/proxy.ts
+++ b/xsuite/src/proxy/proxy.ts
@@ -56,8 +56,9 @@ export class Proxy {
     return getValuesInOrder(res.txsHashes) as string[];
   }
 
-  sendTx(tx: BroadTx) {
-    return this.sendTxs([tx]).then((r) => r[0]);
+  async sendTx(tx: BroadTx) {
+    const res = await this.fetch("/transaction/send", await broadTxToRawTx(tx));
+    return res.txHash as string;
   }
 
   sendTransfers(txs: TransferTx[]) {
@@ -65,7 +66,7 @@ export class Proxy {
   }
 
   sendTransfer(tx: TransferTx) {
-    return this.sendTransfers([tx]).then((r) => r[0]);
+    return this.sendTx(transferTxToTx(tx));
   }
 
   sendDeployContracts(txs: DeployContractTx[]) {
@@ -73,7 +74,7 @@ export class Proxy {
   }
 
   sendDeployContract(tx: DeployContractTx) {
-    return this.sendDeployContracts([tx]).then((r) => r[0]);
+    return this.sendTx(deployContractTxToTx(tx));
   }
 
   sendCallContracts(txs: CallContractTx[]) {
@@ -81,7 +82,7 @@ export class Proxy {
   }
 
   sendCallContract(tx: CallContractTx) {
-    return this.sendCallContracts([tx]).then((r) => r[0]);
+    return this.sendTx(callContractTxToTx(tx));
   }
 
   sendUpgradeContracts(txs: UpgradeContractTx[]) {
@@ -89,7 +90,7 @@ export class Proxy {
   }
 
   sendUpgradeContract(tx: UpgradeContractTx) {
-    return this.sendUpgradeContracts([tx]).then((r) => r[0]);
+    return this.sendTx(upgradeContractTxToTx(tx));
   }
 
   async awaitTx(txHash: string) {
@@ -182,8 +183,10 @@ export class Proxy {
     return this.resolveTxs(txHashes);
   }
 
-  executeTx(tx: BroadTx) {
-    return this.executeTxs([tx]).then((r) => r[0]);
+  async executeTx(tx: BroadTx) {
+    const txHash = await this.sendTx(tx);
+    await this.awaitTx(txHash);
+    return this.resolveTx(txHash);
   }
 
   async doTransfers(txs: TransferTx[]) {
@@ -192,8 +195,10 @@ export class Proxy {
     return this.resolveTransfers(txHashs);
   }
 
-  transfer(tx: TransferTx) {
-    return this.doTransfers([tx]).then((r) => r[0]);
+  async transfer(tx: TransferTx) {
+    const txHash = await this.sendTransfer(tx);
+    await this.awaitTx(txHash);
+    return this.resolveTransfer(txHash);
   }
 
   async deployContracts(txs: DeployContractTx[]) {
@@ -202,8 +207,10 @@ export class Proxy {
     return this.resolveDeployContracts(txHashes);
   }
 
-  deployContract(tx: DeployContractTx) {
-    return this.deployContracts([tx]).then((r) => r[0]);
+  async deployContract(tx: DeployContractTx) {
+    const txHash = await this.sendDeployContract(tx);
+    await this.awaitTx(txHash);
+    return this.resolveDeployContract(txHash);
   }
 
   async callContracts(txs: CallContractTx[]) {
@@ -212,8 +219,10 @@ export class Proxy {
     return this.resolveCallContracts(txHashes);
   }
 
-  callContract(tx: CallContractTx) {
-    return this.callContracts([tx]).then((r) => r[0]);
+  async callContract(tx: CallContractTx) {
+    const txHash = await this.sendCallContract(tx);
+    await this.awaitTx(txHash);
+    return this.resolveCallContract(txHash);
   }
 
   async upgradeContracts(txs: UpgradeContractTx[]) {
@@ -222,8 +231,10 @@ export class Proxy {
     return this.resolveUpgradeContracts(txHashes);
   }
 
-  upgradeContract(tx: UpgradeContractTx) {
-    return this.upgradeContracts([tx]).then((r) => r[0]);
+  async upgradeContract(tx: UpgradeContractTx) {
+    const txHash = await this.sendUpgradeContract(tx);
+    await this.awaitTx(txHash);
+    return this.resolveUpgradeContract(txHash);
   }
 
   async query(query: BroadQuery): Promise<QueryResult> {

--- a/xsuite/src/proxy/proxy.ts
+++ b/xsuite/src/proxy/proxy.ts
@@ -53,7 +53,13 @@ export class Proxy {
       rawTxs.push(await broadTxToRawTx(tx));
     }
     const res = await this.fetch("/transaction/send-multiple", rawTxs);
-    return getValuesInOrder(res.txsHashes) as string[];
+    const txsHashesSent = getValuesInOrder(res.txsHashes) as string[];
+    if (txsHashesSent.length !== rawTxs.length) {
+      throw new Error(
+        `Only ${txsHashesSent.length} of ${rawTxs.length} transactions were sent. The other ones were invalid.`,
+      );
+    }
+    return txsHashesSent;
   }
 
   async sendTx(tx: BroadTx) {

--- a/xsuite/src/world/fsworld.test.ts
+++ b/xsuite/src/world/fsworld.test.ts
@@ -436,6 +436,44 @@ test.concurrent("FSWorld.transfer", async () => {
   });
 });
 
+test.todo.concurrent(
+  "FSWorld.transfer - invalid tx - cannot pay fee",
+  async () => {
+    using world = await FSWorld.start();
+    const wallet = await world.createWallet();
+    await expect(
+      world.transfer({
+        sender: wallet,
+        receiver: wallet,
+        value: 0,
+        gasLimit: 100_000,
+      }),
+    ).rejects.toThrow(
+      `insufficient funds for address ${(await wallet.getAccount()).address}`,
+    );
+  },
+);
+
+test.todo.concurrent(
+  "FSWorld.doTransfers - invalid tx - cannot pay fee",
+  async () => {
+    using world = await FSWorld.start();
+    const wallet = await world.createWallet();
+    await expect(
+      world.doTransfers([
+        {
+          sender: wallet,
+          receiver: wallet,
+          value: 0,
+          gasLimit: 100_000,
+        },
+      ]),
+    ).rejects.toThrow(
+      "Only 0 of 1 transactions were sent. The other ones were invalid.",
+    );
+  },
+);
+
 test.concurrent("FSWorld.deployContract", async () => {
   using world = await FSWorld.start({ explorerUrl: baseExplorerUrl });
   const { wallet } = await createAccounts(world);

--- a/xsuite/src/world/fsworld.test.ts
+++ b/xsuite/src/world/fsworld.test.ts
@@ -436,36 +436,36 @@ test.concurrent("FSWorld.transfer", async () => {
   });
 });
 
-test.todo.concurrent(
-  "FSWorld.transfer - invalid tx - cannot pay fee",
+test.concurrent(
+  "FSWorld.transfer - invalid tx - gasLimit too low",
   async () => {
     using world = await FSWorld.start();
-    const wallet = await world.createWallet();
+    const { wallet } = await createAccounts(world);
     await expect(
       world.transfer({
         sender: wallet,
         receiver: wallet,
         value: 0,
-        gasLimit: 100_000,
+        gasLimit: 0,
       }),
     ).rejects.toThrow(
-      `insufficient funds for address ${(await wallet.getAccount()).address}`,
+      "transaction generation failed: insufficient gas limit in tx",
     );
   },
 );
 
-test.todo.concurrent(
-  "FSWorld.doTransfers - invalid tx - cannot pay fee",
+test.concurrent(
+  "FSWorld.doTransfers - invalid tx - gasLimit too low",
   async () => {
     using world = await FSWorld.start();
-    const wallet = await world.createWallet();
+    const { wallet } = await createAccounts(world);
     await expect(
       world.doTransfers([
         {
           sender: wallet,
           receiver: wallet,
           value: 0,
-          gasLimit: 100_000,
+          gasLimit: 0,
         },
       ]),
     ).rejects.toThrow(

--- a/xsuite/src/world/lsworld.test.ts
+++ b/xsuite/src/world/lsworld.test.ts
@@ -487,6 +487,41 @@ test.concurrent("LSWorld.transfer", async () => {
   });
 });
 
+test.concurrent("LSWorld.transfer - invalid tx - cannot pay fee", async () => {
+  using world = await LSWorld.start({ gasPrice: 1_000_000 });
+  const wallet = await world.createWallet();
+  await expect(
+    world.transfer({
+      sender: wallet,
+      receiver: wallet,
+      value: 0,
+      gasLimit: 100_000,
+    }),
+  ).rejects.toThrow(
+    "could not set up tx : not enough balance to pay gas upfront",
+  );
+});
+
+test.concurrent(
+  "LSWorld.doTransfers - invalid tx - cannot pay fee",
+  async () => {
+    using world = await LSWorld.start({ gasPrice: 1_000_000 });
+    const wallet = await world.createWallet();
+    await expect(
+      world.doTransfers([
+        {
+          sender: wallet,
+          receiver: wallet,
+          value: 0,
+          gasLimit: 100_000,
+        },
+      ]),
+    ).rejects.toThrow(
+      "Only 0 of 1 transactions were sent. The other ones were invalid.",
+    );
+  },
+);
+
 test.concurrent("LSWorld.deployContract", async () => {
   using world = await LSWorld.start({ explorerUrl: baseExplorerUrl });
   const { wallet } = await createAccounts(world);

--- a/xsuite/src/world/lsworld.test.ts
+++ b/xsuite/src/world/lsworld.test.ts
@@ -487,33 +487,34 @@ test.concurrent("LSWorld.transfer", async () => {
   });
 });
 
-test.concurrent("LSWorld.transfer - invalid tx - cannot pay fee", async () => {
-  using world = await LSWorld.start({ gasPrice: 1_000_000 });
-  const wallet = await world.createWallet();
-  await expect(
-    world.transfer({
-      sender: wallet,
-      receiver: wallet,
-      value: 0,
-      gasLimit: 100_000,
-    }),
-  ).rejects.toThrow(
-    "could not set up tx : not enough balance to pay gas upfront",
-  );
-});
+test.concurrent(
+  "LSWorld.transfer - invalid tx - gasLimit too low",
+  async () => {
+    using world = await LSWorld.start();
+    const { wallet } = await createAccounts(world);
+    await expect(
+      world.transfer({
+        sender: wallet,
+        receiver: wallet,
+        value: 0,
+        gasLimit: 0,
+      }),
+    ).rejects.toThrow("insufficient gas limit");
+  },
+);
 
 test.concurrent(
-  "LSWorld.doTransfers - invalid tx - cannot pay fee",
+  "LSWorld.doTransfers - invalid tx - gasLimit too low",
   async () => {
-    using world = await LSWorld.start({ gasPrice: 1_000_000 });
-    const wallet = await world.createWallet();
+    using world = await LSWorld.start();
+    const { wallet } = await createAccounts(world);
     await expect(
       world.doTransfers([
         {
           sender: wallet,
           receiver: wallet,
           value: 0,
-          gasLimit: 100_000,
+          gasLimit: 0,
         },
       ]),
     ).rejects.toThrow(


### PR DESCRIPTION
Closes #163, closes #164.

Full Simulnet doesn't return an error when sending an invalid transaction through `/transaction/send`. It also doesn't remove the transaction hash (in its response) of an invalid transaction sent through `/transaction/send-multiple`.

Then, we will need to remove the `todo` flags from the tests `FSWorld.transfer - invalid tx - cannot pay fee` and `FSWorld.doTransfers - invalid tx - cannot pay fee` once Full Simulnet correctly handles these cases.