### PR TITLE
Add endpoint `/address/[address]/key/[key]`

### DIFF
--- a/xsuite-lightsimulnet/src/handleAddress.go
+++ b/xsuite-lightsimulnet/src/handleAddress.go
@@ -61,6 +61,28 @@ func (e *Executor) HandleAddressBalance(r *http.Request) (interface{}, error) {
 	return jData, nil
 }
 
+func (e *Executor) HandleAddressKey(r *http.Request) (interface{}, error) {
+	bechAddress := chi.URLParam(r, "address")
+	address, err := bech32Decode(bechAddress)
+	if err != nil {
+		return nil, err
+	}
+	key := chi.URLParam(r, "key")
+	_, err = hex.DecodeString(key)
+	if err != nil {
+		return nil, err
+	}
+	worldAccount := e.getWorldAccount(address)
+	value := e.getAccountValueData(worldAccount, key)
+	jData := map[string]interface{}{
+		"data": map[string]interface{}{
+			"value": value,
+		},
+		"code": "successful",
+	}
+	return jData, nil
+}
+
 func (e *Executor) HandleAddressKeys(r *http.Request) (interface{}, error) {
 	bechAddress := chi.URLParam(r, "address")
 	address, err := bech32Decode(bechAddress)
@@ -131,4 +153,13 @@ func (e *Executor) getAccountKvsData(worldAccount *worldmock.Account) interface{
 		}
 	}
 	return data
+}
+
+func (e *Executor) getAccountValueData(worldAccount *worldmock.Account, key string) string {
+	for k, v := range worldAccount.Storage {
+		if hex.EncodeToString([]byte(k)) == key {
+			return hex.EncodeToString(v)
+		}
+	}
+	return ""
 }

--- a/xsuite-lightsimulnet/src/handleAddress.go
+++ b/xsuite-lightsimulnet/src/handleAddress.go
@@ -68,12 +68,12 @@ func (e *Executor) HandleAddressKey(r *http.Request) (interface{}, error) {
 		return nil, err
 	}
 	key := chi.URLParam(r, "key")
-	_, err = hex.DecodeString(key)
+	bytesKey, err := hex.DecodeString(key)
 	if err != nil {
 		return nil, err
 	}
 	worldAccount := e.getWorldAccount(address)
-	value := e.getAccountValueData(worldAccount, key)
+	value := e.getAccountValueData(worldAccount, bytesKey)
 	jData := map[string]interface{}{
 		"data": map[string]interface{}{
 			"value": value,
@@ -155,11 +155,7 @@ func (e *Executor) getAccountKvsData(worldAccount *worldmock.Account) interface{
 	return data
 }
 
-func (e *Executor) getAccountValueData(worldAccount *worldmock.Account, key string) string {
-	for k, v := range worldAccount.Storage {
-		if hex.EncodeToString([]byte(k)) == key {
-			return hex.EncodeToString(v)
-		}
-	}
-	return ""
+func (e *Executor) getAccountValueData(worldAccount *worldmock.Account, bytesKey []byte) string {
+	value := worldAccount.Storage[string(bytesKey)]
+	return hex.EncodeToString(value)
 }

--- a/xsuite-lightsimulnet/src/main.go
+++ b/xsuite-lightsimulnet/src/main.go
@@ -47,6 +47,11 @@ func main() {
 		respond(w, resBody, err)
 	})
 
+	router.Get("/address/{address}/key/{key}", func(w http.ResponseWriter, r *http.Request) {
+		resBody, err := executor.HandleAddressKey(r)
+		respond(w, resBody, err)
+	})
+
 	router.Post("/transaction/send", func(w http.ResponseWriter, r *http.Request) {
 		resBody, err := executor.HandleTransactionSend(r)
 		respond(w, resBody, err)

--- a/xsuite/src/proxy/proxy.ts
+++ b/xsuite/src/proxy/proxy.ts
@@ -318,6 +318,19 @@ export class Proxy {
     return BigInt(res.balance);
   }
 
+  async getAccountValue(
+    address: AddressLike,
+    key: string,
+    { shardId }: GetAccountOptions = {},
+  ): Promise<string> {
+    const res = await this.fetch(
+      makePath(`/address/${addressLikeToBechAddress(address)}/key/${key}`, {
+        "forced-shard-id": shardId,
+      }),
+    );
+    return res.value;
+  }
+
   async getAccountKvs(
     address: AddressLike,
     { shardId }: GetAccountOptions = {},

--- a/xsuite/src/proxy/proxy.ts
+++ b/xsuite/src/proxy/proxy.ts
@@ -5,7 +5,7 @@ import {
   addressLikeToBechAddress,
   addressLikeToHexAddress,
 } from "../data/addressLike";
-import { BytesLike } from "../data/bytesLike";
+import { BytesLike, bytesLikeToHex } from "../data/bytesLike";
 import {
   Encodable,
   EncodableCodeMetadata,
@@ -320,13 +320,18 @@ export class Proxy {
 
   async getAccountValue(
     address: AddressLike,
-    key: string,
+    key: BytesLike,
     { shardId }: GetAccountOptions = {},
   ): Promise<string> {
     const res = await this.fetch(
-      makePath(`/address/${addressLikeToBechAddress(address)}/key/${key}`, {
-        "forced-shard-id": shardId,
-      }),
+      makePath(
+        `/address/${addressLikeToBechAddress(address)}/key/${bytesLikeToHex(
+          key,
+        )}`,
+        {
+          "forced-shard-id": shardId,
+        },
+      ),
     );
     return res.value;
   }

--- a/xsuite/src/world/fsworld.test.ts
+++ b/xsuite/src/world/fsworld.test.ts
@@ -964,10 +964,7 @@ test.concurrent("FSContract.getAccountBalance", async () => {
 
 test.concurrent("FSContract.getAccountValue", async () => {
   using world = await FSWorld.start();
-  const { wallet } = await createAccounts(world);
-  const contract = await wallet.createContract({
-    code: worldCode,
-    codeMetadata: ["readable"],
+  const contract = await world.createContract({
     kvs: { "01": "11" },
   });
   expect(await contract.getAccountValue("01")).toEqual("11");

--- a/xsuite/src/world/lsworld.test.ts
+++ b/xsuite/src/world/lsworld.test.ts
@@ -1001,10 +1001,7 @@ test.concurrent("LSContract.getAccountBalance", async () => {
 
 test.concurrent("LSContract.getAccountValue", async () => {
   using world = await LSWorld.start();
-  const { wallet } = await createAccounts(world);
-  const contract = await wallet.createContract({
-    code: worldCode,
-    codeMetadata: ["readable"],
+  const contract = await world.createContract({
     kvs: { "01": "11" },
   });
   expect(await contract.getAccountValue("01")).toEqual("11");

--- a/xsuite/src/world/world.ts
+++ b/xsuite/src/world/world.ts
@@ -116,6 +116,10 @@ export class World {
     return this.proxy.getAccountBalance(address);
   }
 
+  getAccountValue(address: AddressLike, key: string) {
+    return this.proxy.getAccountValue(address, key);
+  }
+
   getAccountKvs(address: AddressLike) {
     return this.proxy.getAccountKvs(address);
   }
@@ -357,6 +361,10 @@ export class Wallet extends Signer {
 
   getAccountBalance() {
     return this.world.getAccountBalance(this);
+  }
+
+  getAccountValue(key: string) {
+    return this.world.getAccountValue(this, key);
   }
 
   getAccountKvs() {

--- a/xsuite/src/world/world.ts
+++ b/xsuite/src/world/world.ts
@@ -463,6 +463,10 @@ export class Contract extends Account {
     return this.world.getAccountBalance(this);
   }
 
+  getAccountValue(key: string) {
+    return this.world.getAccountValue(this, key);
+  }
+
   getAccountKvs() {
     return this.world.getAccountKvs(this);
   }

--- a/xsuite/src/world/world.ts
+++ b/xsuite/src/world/world.ts
@@ -1,4 +1,5 @@
 import { AddressLike, addressLikeToBechAddress } from "../data/addressLike";
+import { BytesLike } from "../data/bytesLike";
 import { Optional, Prettify, Replace } from "../helpers";
 import {
   devnetChainId,
@@ -116,7 +117,7 @@ export class World {
     return this.proxy.getAccountBalance(address);
   }
 
-  getAccountValue(address: AddressLike, key: string) {
+  getAccountValue(address: AddressLike, key: BytesLike) {
     return this.proxy.getAccountValue(address, key);
   }
 
@@ -363,7 +364,7 @@ export class Wallet extends Signer {
     return this.world.getAccountBalance(this);
   }
 
-  getAccountValue(key: string) {
+  getAccountValue(key: BytesLike) {
     return this.world.getAccountValue(this, key);
   }
 
@@ -463,7 +464,7 @@ export class Contract extends Account {
     return this.world.getAccountBalance(this);
   }
 
-  getAccountValue(key: string) {
+  getAccountValue(key: BytesLike) {
     return this.world.getAccountValue(this, key);
   }
 


### PR DESCRIPTION
The light simulnet implementation tries to match as close as possible the blockchain behavior by:
- Raising an error if the provided key is not a correct hex string
- Sending back an empty string if the asked key is not found

Tests are needed and maybe we could also find a better way to provide a key to the method `getAccountValue`

Closes #186 