### PR TITLE
Add blockNonce option to Proxy

### DIFF
--- a/xsuite/src/proxy/proxy.ts
+++ b/xsuite/src/proxy/proxy.ts
@@ -19,22 +19,28 @@ export class Proxy {
   proxyUrl: string;
   headers: HeadersInit;
   explorerUrl: string;
+  blockNonce: number | null;
 
   constructor(params: ProxyParams) {
     params = typeof params === "string" ? { proxyUrl: params } : params;
     this.proxyUrl = params.proxyUrl;
     this.headers = params.headers ?? {};
     this.explorerUrl = params.explorerUrl ?? "";
+    this.blockNonce = params.blockNonce ?? null;
   }
 
   fetchRaw(path: string, data?: any) {
     const baseUrl = this.proxyUrl;
     const init: RequestInit = { headers: this.headers };
+    const url = new URL(`${baseUrl}${path}`);
+    if (this.blockNonce !== null) {
+      url.searchParams.append("blockNonce", this.blockNonce.toString());
+    }
     if (data !== undefined) {
       init.method = "POST";
       init.body = JSON.stringify(data);
     }
-    return fetch(`${baseUrl}${path}`, init).then((r) => r.json());
+    return fetch(url.toString(), init).then((r) => r.json());
   }
 
   async fetch(path: string, data?: any) {
@@ -623,7 +629,12 @@ export const pendingErrorMessage = "Transaction still pending.";
 
 export type ProxyParams =
   | string
-  | { proxyUrl: string; headers?: HeadersInit; explorerUrl?: string };
+  | {
+      proxyUrl: string;
+      headers?: HeadersInit;
+      explorerUrl?: string;
+      blockNonce?: number;
+    };
 
 type BroadTx = Tx | RawTx;
 

--- a/xsuite/src/world/fsworld.test.ts
+++ b/xsuite/src/world/fsworld.test.ts
@@ -105,6 +105,23 @@ test.concurrent("FSWorld.proxy.getAccount on empty U8A address", async () => {
   assertAccount(await world.proxy.getAccount(zeroU8AAddress), emptyAccount);
 });
 
+test.concurrent("FSWorld.proxy.blockNonce", async () => {
+  using world = await FSWorld.start();
+  const wallet = await world.createWallet({
+    balance: 10n ** 18n,
+  });
+  await wallet.setAccount({
+    balance: 2n * 10n ** 18n,
+  });
+  assertAccount(await wallet.getAccount(), {
+    balance: 2n * 10n ** 18n,
+  });
+  world.proxy.blockNonce = 2;
+  assertAccount(await wallet.getAccount(), {
+    balance: 10n ** 18n,
+  });
+});
+
 test.concurrent("FSWorld.new with defined chainId", () => {
   expect(() => FSWorld.new({ chainId: "D" })).toThrow(
     "chainId is not undefined.",


### PR DESCRIPTION
Adding the `blockNonce` searchParam at the `fetchRaw` level make us build the url 2 times for some endpoints:
- with `makePath`
- with `URL` obejct
We could imagine redesign a bit the proxy to use only one time the `URL` object.

Closes #180 