### PR TITLE
Add key encoders 

### DIFF
--- a/xsuite/src/data/encoding.ts
+++ b/xsuite/src/data/encoding.ts
@@ -251,6 +251,10 @@ export const e = {
     }
     return account as PreserveDefinedness<T, Account>;
   },
+  MapperKey: (...args: EncodableMapperKeyArgs) => {
+    const [name, ...vars] = args;
+    return e.Tuple(e.TopStr(name), ...vars);
+  },
   /**
    * @deprecated Use `.TopBuffer` instead.
    */
@@ -581,7 +585,7 @@ const newEncodable = (
 function curryEKvsMapper<T2, R>(fn: (baseKey: Encodable, data: T2) => R) {
   return function ([name, ...vars]: EncodableMapperKeyArgs): (data: T2) => R {
     return function (data: T2): R {
-      return fn(e.Tuple(e.TopStr(name), ...vars), data);
+      return fn(e.MapperKey(name, ...vars), data);
     };
   };
 }

--- a/xsuite/src/data/encoding.ts
+++ b/xsuite/src/data/encoding.ts
@@ -201,6 +201,16 @@ export const e = {
     }
     return newEncodable(() => new Uint8Array([1, ...optEncodable.toNestU8A()]));
   },
+  MapperKey: (...args: EncodableMapperKeyArgs) => {
+    const [name, ...vars] = args;
+    return e.Tuple(e.TopStr(name), ...vars);
+  },
+  EsdtKey: (id: string, nonce?: number | bigint) =>
+    nonce
+      ? e.Tuple(e.TopStr(`ELRONDesdt${id}`), e.TopU(nonce))
+      : e.TopStr(`ELRONDesdt${id}`),
+  EsdtRolesKey: (id: string) => e.TopStr(`ELRONDroleesdt${id}`),
+  EsdtLastNonceKey: (id: string) => e.TopStr(`ELRONDnonce${id}`),
   vs: (encodableVs: EncodableVs): Vs => {
     return encodableVs.map(bytesLikeToHex);
   },
@@ -251,16 +261,6 @@ export const e = {
     }
     return account as PreserveDefinedness<T, Account>;
   },
-  MapperKey: (...args: EncodableMapperKeyArgs) => {
-    const [name, ...vars] = args;
-    return e.Tuple(e.TopStr(name), ...vars);
-  },
-  EsdtRolesKey: (id: string) => e.TopStr(`ELRONDroleesdt${id}`),
-  EsdtLastNonceKey: (id: string) => e.TopStr(`ELRONDnonce${id}`),
-  EsdtKey: (id: string, nonce?: number | bigint) =>
-    nonce
-      ? e.Tuple(e.TopStr(`ELRONDesdt${id}`), e.TopU(nonce))
-      : e.TopStr(`ELRONDesdt${id}`),
   /**
    * @deprecated Use `.TopBuffer` instead.
    */

--- a/xsuite/src/data/index.test.ts
+++ b/xsuite/src/data/index.test.ts
@@ -842,6 +842,52 @@ test("e.account", async () => {
   );
 });
 
+test("e.MapperKey - simple key", () => {
+  expect(e.MapperKey("key").toTopHex()).toEqual("6b6579");
+  expect(e.MapperKey("key").toNestHex()).toEqual("6b6579");
+});
+
+test("e.MapperKey - complex key", () => {
+  expect(e.MapperKey("key", e.U32(1)).toTopHex()).toEqual("6b657900000001");
+  expect(e.MapperKey("key", e.U32(1)).toNestHex()).toEqual("6b657900000001");
+});
+
+test("e.EsdtRolesKey", () => {
+  expect(e.EsdtRolesKey("TOKEN-123456").toTopHex()).toEqual(
+    "454c524f4e44726f6c6565736474544f4b454e2d313233343536",
+  );
+  expect(e.EsdtRolesKey("TOKEN-123456").toNestHex()).toEqual(
+    "454c524f4e44726f6c6565736474544f4b454e2d313233343536",
+  );
+});
+
+test("e.EsdtLastNonceKey", () => {
+  expect(e.EsdtLastNonceKey("TOKEN-123456").toTopHex()).toEqual(
+    "454c524f4e446e6f6e6365544f4b454e2d313233343536",
+  );
+  expect(e.EsdtLastNonceKey("TOKEN-123456").toNestHex()).toEqual(
+    "454c524f4e446e6f6e6365544f4b454e2d313233343536",
+  );
+});
+
+test("e.EsdtKey - without nonce", () => {
+  expect(e.EsdtKey("TOKEN-123456").toTopHex()).toEqual(
+    "454c524f4e4465736474544f4b454e2d313233343536",
+  );
+  expect(e.EsdtKey("TOKEN-123456").toNestHex()).toEqual(
+    "454c524f4e4465736474544f4b454e2d313233343536",
+  );
+});
+
+test("e.EsdtKey - with nonce", () => {
+  expect(e.EsdtKey("TOKEN-123456", 1).toTopHex()).toEqual(
+    "454c524f4e4465736474544f4b454e2d31323334353601",
+  );
+  expect(e.EsdtKey("TOKEN-123456", 1).toNestHex()).toEqual(
+    "454c524f4e4465736474544f4b454e2d31323334353601",
+  );
+});
+
 test("e.Bytes.toNestHex", () => {
   expect(e.Bytes(new Uint8Array([65, 66, 67])).toNestHex()).toEqual("414243");
 });

--- a/xsuite/src/data/index.test.ts
+++ b/xsuite/src/data/index.test.ts
@@ -618,6 +618,70 @@ test("e.Option.toNestHex - e.U(256)", () => {
   expect(e.Option(e.U(256)).toNestHex()).toEqual("01000000020100");
 });
 
+test("e.MapperKey.toTopHex - simple key", () => {
+  expect(e.MapperKey("key").toTopHex()).toEqual("6b6579");
+});
+
+test("e.MapperKey.toNestHex - simple key", () => {
+  expect(e.MapperKey("key").toNestHex()).toEqual("6b6579");
+});
+
+test("e.MapperKey.toTopHex - complex key", () => {
+  expect(e.MapperKey("key", e.U32(1)).toTopHex()).toEqual("6b657900000001");
+});
+
+test("e.MapperKey.toNestHex - complex key", () => {
+  expect(e.MapperKey("key", e.U32(1)).toNestHex()).toEqual("6b657900000001");
+});
+
+test("e.EsdtKey.toTopHex - without nonce", () => {
+  expect(e.EsdtKey("TOKEN-123456").toTopHex()).toEqual(
+    "454c524f4e4465736474544f4b454e2d313233343536",
+  );
+});
+
+test("e.EsdtKey.toNestHex - without nonce", () => {
+  expect(e.EsdtKey("TOKEN-123456").toNestHex()).toEqual(
+    "454c524f4e4465736474544f4b454e2d313233343536",
+  );
+});
+
+test("e.EsdtKey.toTopHex - with nonce", () => {
+  expect(e.EsdtKey("TOKEN-123456", 1).toTopHex()).toEqual(
+    "454c524f4e4465736474544f4b454e2d31323334353601",
+  );
+});
+
+test("e.EsdtKey.toNestHex - with nonce", () => {
+  expect(e.EsdtKey("TOKEN-123456", 1).toNestHex()).toEqual(
+    "454c524f4e4465736474544f4b454e2d31323334353601",
+  );
+});
+
+test("e.EsdtRolesKey.toTopHex", () => {
+  expect(e.EsdtRolesKey("TOKEN-123456").toTopHex()).toEqual(
+    "454c524f4e44726f6c6565736474544f4b454e2d313233343536",
+  );
+});
+
+test("e.EsdtRolesKey.toNestHex", () => {
+  expect(e.EsdtRolesKey("TOKEN-123456").toNestHex()).toEqual(
+    "454c524f4e44726f6c6565736474544f4b454e2d313233343536",
+  );
+});
+
+test("e.EsdtLastNonceKey.toTopHex", () => {
+  expect(e.EsdtLastNonceKey("TOKEN-123456").toTopHex()).toEqual(
+    "454c524f4e446e6f6e6365544f4b454e2d313233343536",
+  );
+});
+
+test("e.EsdtLastNonceKey.toNestHex", () => {
+  expect(e.EsdtLastNonceKey("TOKEN-123456").toNestHex()).toEqual(
+    "454c524f4e446e6f6e6365544f4b454e2d313233343536",
+  );
+});
+
 test("e.vs", () => {
   expect(e.vs(["0102", "0304", new Uint8Array([5, 6]), e.U8(10)])).toEqual(vs);
 });
@@ -839,52 +903,6 @@ test("e.account", async () => {
       kvs: complexSysAccState.kvs,
       owner: "",
     }),
-  );
-});
-
-test("e.MapperKey - simple key", () => {
-  expect(e.MapperKey("key").toTopHex()).toEqual("6b6579");
-  expect(e.MapperKey("key").toNestHex()).toEqual("6b6579");
-});
-
-test("e.MapperKey - complex key", () => {
-  expect(e.MapperKey("key", e.U32(1)).toTopHex()).toEqual("6b657900000001");
-  expect(e.MapperKey("key", e.U32(1)).toNestHex()).toEqual("6b657900000001");
-});
-
-test("e.EsdtRolesKey", () => {
-  expect(e.EsdtRolesKey("TOKEN-123456").toTopHex()).toEqual(
-    "454c524f4e44726f6c6565736474544f4b454e2d313233343536",
-  );
-  expect(e.EsdtRolesKey("TOKEN-123456").toNestHex()).toEqual(
-    "454c524f4e44726f6c6565736474544f4b454e2d313233343536",
-  );
-});
-
-test("e.EsdtLastNonceKey", () => {
-  expect(e.EsdtLastNonceKey("TOKEN-123456").toTopHex()).toEqual(
-    "454c524f4e446e6f6e6365544f4b454e2d313233343536",
-  );
-  expect(e.EsdtLastNonceKey("TOKEN-123456").toNestHex()).toEqual(
-    "454c524f4e446e6f6e6365544f4b454e2d313233343536",
-  );
-});
-
-test("e.EsdtKey - without nonce", () => {
-  expect(e.EsdtKey("TOKEN-123456").toTopHex()).toEqual(
-    "454c524f4e4465736474544f4b454e2d313233343536",
-  );
-  expect(e.EsdtKey("TOKEN-123456").toNestHex()).toEqual(
-    "454c524f4e4465736474544f4b454e2d313233343536",
-  );
-});
-
-test("e.EsdtKey - with nonce", () => {
-  expect(e.EsdtKey("TOKEN-123456", 1).toTopHex()).toEqual(
-    "454c524f4e4465736474544f4b454e2d31323334353601",
-  );
-  expect(e.EsdtKey("TOKEN-123456", 1).toNestHex()).toEqual(
-    "454c524f4e4465736474544f4b454e2d31323334353601",
   );
 });
 


### PR DESCRIPTION
The main reason we added those encoders is for the use of `Proxy.getAccountValue()`.

In the case of a Mapper value, its totally fine for the user to use `d` to decode the returned value. But what if he is trying to get an Esdt value? Maybe we should add a decoder in the `d` object that simply decodes an Esdt value?

Closes #190